### PR TITLE
Fixed Color calibration not working on some devices as Find7a

### DIFF
--- a/hardware/src/main/java/at/amartinz/hardware/display/DisplayColorCalibration.java
+++ b/hardware/src/main/java/at/amartinz/hardware/display/DisplayColorCalibration.java
@@ -104,7 +104,7 @@ public class DisplayColorCalibration {
 
     public int getDefValue() { return HwUtils.tryParseInt(def); }
 
-    @Nullable public String getCurColors() { return HwIoUtils.readOneLine(path); }
+    @Nullable public String getCurColors() { return HwIoUtils.readOneLineRoot(path); }
 
     public void setColors(final String colors) {
         final StringBuilder sb = new StringBuilder();

--- a/hardware/src/main/java/at/amartinz/hardware/utils/HwIoUtils.java
+++ b/hardware/src/main/java/at/amartinz/hardware/utils/HwIoUtils.java
@@ -213,6 +213,40 @@ public class HwIoUtils {
         return ((content != null) ? content.trim() : null);
     }
 
+	/**
+     * Read one line from a file with root credentials.
+     * Use blocking reading.
+     * @param Path of the file to read
+     * @return Line read.
+     */
+    @WorkerThread @Nullable public static String readOneLineRoot(final String path) {
+        final String content = readFileInternalRoot(path, true);
+        return ((content != null) ? content.trim() : null);
+    }
+
+	/**
+	 * Read file with root permissions.
+     * @param path Path of the file to read
+     * @param oneLine read only one line if true
+     * @return content read
+     */
+    @WorkerThread
+    @Nullable
+    public static String readFileInternalRoot(@Nullable final String path, boolean oneLine) {
+        if (TextUtils.isEmpty(path) || !RootCheck.isRooted()) {
+            return null;
+        }
+        String output = null;
+        if(oneLine)
+            output = RootShell.fireAndBlockStringNewline(
+                    new Command(String.format("head -n 1 %s", path)));
+        else
+            output = RootShell.fireAndBlockStringNewline(
+                    new Command(String.format("cat %s", path)));
+
+        return output;
+    }
+
     @WorkerThread @Nullable private static String readFileInternal(final String path, final boolean oneLine) {
         final File f = new File(path);
         if (f.canRead()) {


### PR DESCRIPTION
Issue: Cannot use color calibration in Device Control app

The problem was that getCurColors() which is supposed to read current rgb values from a file in /sys/... was not able to read it because of its lack of root permissions. Necessary permissions to read the file must have changed with Android 6 or whatever. 

I added two functions : 
HwIoUtils.readOneLineRoot(String path) and HwIoUtilsreadFileInternalRoot(final String path, boolean oneLine), which do the same thing as their counterparts without root. The reading is blocking so it's making the patch simpler. (that's the reason I didn't use the existing async reading method which I found not suitable in this use case)

It works on my device and should not cause any issues applied to other devices. 
Hope you will consider this patch, thank you.